### PR TITLE
h[key] can be nil in which case the line will bomb out...

### DIFF
--- a/lib/widgets/highlightable.rb
+++ b/lib/widgets/highlightable.rb
@@ -49,6 +49,7 @@ module Widgets
           elsif highlight.kind_of? Hash # evaluate the hash
             h = clean_unwanted_keys(highlight)
             h.each_key do |key|   # for each key
+              next if h[key].nil?
               # remove first slash from <tt>:controller</tt> key otherwise highlighted? could fail with urls such as {:controller => "/base"</tt>
               h_key = h[key].to_param.dup
               h_key.gsub!(/^\//,"") if key == :controller          


### PR DESCRIPTION
Under Rails3.0 I'd get a "can't dup NilClass" in some random view that would render tabs.

When debuggin this I saw this here (this from the debugger):

<pre>
/Users/itz/leihs-git/vendor/plugins/rails-widgets/lib/widgets/highlightable.rb:53
h_key = h[key].to_param.dup
(rdb:622) l
   48              end
   49            elsif highlight.kind_of? Hash # evaluate the hash
   50              h = clean_unwanted_keys(highlight)
   51              h.each_key do |key|   # for each key
   52                # remove first slash from <tt>:controller</tt> key otherwise highlighted? could fail with urls such as {:controller => "/base"</tt>
=> 53                h_key = h[key].to_param.dup
   54                h_key.gsub!(/^\//,"") if key == :controller          
   55                highlighted &= h_key==options[key].to_s
   56              end
   57            else # highlighting rule not supported

(rdb:623) pp h
{:controller=>"backend/models",
 :action=>"show",
 :layout=>"modal",
 :id=>
  #<Model id: 2443, name: "\tHD-Kamera Panasonic HDC-TM700", manufacturer: "Panasonic", description: " \r\n\r\nFull HD Camcorder mit 3MOS Kamerasystem, 35mm ...", internal_description: "", info_url: nil, rental_price: nil, maintenance_period: 0, is_package: false, created_at: "2010-10-01 14:00:09", updated_at: "2011-06-28 09:35:42", technical_detail: "", delta: true, hand_over_note: nil>,
 :filter=>nil}
</pre>


Note the last line of the printout of the "h" Hash. It's got a key with value 'nil'. Thus doing a 'h[:filter]' would give us 'nil', applying '.to_param' on 'nil' would still return 'nil'. And then calling '.dup' on nil would bomb with "can't dup NilClass".

I have no clue what's happening in the code there, I've just added a

<pre>
next if h[key].nil?
</pre>


but that's a band-aid only that fixes my itch but nothing more. Finding out what that 'highlighted?' method actually is expecting and what it's intended semantics are would be better.
